### PR TITLE
Fix type inference bug in _is_newer_version

### DIFF
--- a/addons/godotiq/godotiq_server.gd
+++ b/addons/godotiq/godotiq_server.gd
@@ -126,7 +126,7 @@ func _on_update_check_completed(result: int, response_code: int, _headers: Packe
 func _is_newer_version(remote: String, local: String) -> bool:
 	var r := remote.split(".")
 	var l := local.split(".")
-	var max_len := max(r.size(), l.size())
+	var max_len: int = max(r.size(), l.size())
 	for i in range(max_len):
 		var rv: int = int(r[i]) if i < r.size() else 0
 		var lv: int = int(l[i]) if i < l.size() else 0


### PR DESCRIPTION
## Summary
- `max()` returns `float` in GDScript, so `var max_len := max(r.size(), l.size())` infers as `float` instead of `int`
- This causes a compilation error since `max_len` is used with `range()` and in integer comparisons
- Restores the explicit `int` type annotation: `var max_len: int = max(r.size(), l.size())`

## Impact
The compilation error in `godotiq_server.gd` prevents the GodotIQ addon from loading in the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)